### PR TITLE
Add binding metadata

### DIFF
--- a/domain/apiresponses/responses.go
+++ b/domain/apiresponses/responses.go
@@ -67,6 +67,7 @@ type BindingResponse struct {
 	RouteServiceURL string               `json:"route_service_url,omitempty"`
 	VolumeMounts    []domain.VolumeMount `json:"volume_mounts,omitempty"`
 	BackupAgentURL  string               `json:"backup_agent_url,omitempty"`
+	Metadata        any                  `json:"metadata,omitempty"`
 }
 
 type GetBindingResponse struct {

--- a/domain/service_broker.go
+++ b/domain/service_broker.go
@@ -190,14 +190,20 @@ type UnbindSpec struct {
 }
 
 type Binding struct {
-	IsAsync         bool          `json:"is_async"`
-	AlreadyExists   bool          `json:"already_exists"`
-	OperationData   string        `json:"operation_data"`
-	Credentials     interface{}   `json:"credentials"`
-	SyslogDrainURL  string        `json:"syslog_drain_url"`
-	RouteServiceURL string        `json:"route_service_url"`
-	BackupAgentURL  string        `json:"backup_agent_url,omitempty"`
-	VolumeMounts    []VolumeMount `json:"volume_mounts"`
+	IsAsync         bool            `json:"is_async"`
+	AlreadyExists   bool            `json:"already_exists"`
+	OperationData   string          `json:"operation_data"`
+	Credentials     interface{}     `json:"credentials"`
+	SyslogDrainURL  string          `json:"syslog_drain_url"`
+	RouteServiceURL string          `json:"route_service_url"`
+	BackupAgentURL  string          `json:"backup_agent_url,omitempty"`
+	VolumeMounts    []VolumeMount   `json:"volume_mounts"`
+	Metadata        BindingMetadata `json:"metadata,omitempty"`
+}
+
+type BindingMetadata struct {
+	ExpiresAt   string `json:"expires_at,omitempty"`
+	RenewBefore string `json:"renew_before,omitempty"`
 }
 
 type GetBindingSpec struct {
@@ -206,6 +212,7 @@ type GetBindingSpec struct {
 	RouteServiceURL string
 	VolumeMounts    []VolumeMount
 	Parameters      interface{}
+	Metadata        BindingMetadata
 }
 
 func (d ProvisionDetails) GetRawContext() json.RawMessage {
@@ -226,6 +233,10 @@ func (d BindDetails) GetRawParameters() json.RawMessage {
 
 func (m InstanceMetadata) IsEmpty() bool {
 	return len(m.Attributes) == 0 && len(m.Labels) == 0
+}
+
+func (m BindingMetadata) IsEmpty() bool {
+	return len(m.ExpiresAt) == 0 && len(m.RenewBefore) == 0
 }
 
 func (d UpdateDetails) GetRawContext() json.RawMessage {

--- a/handlers/bind.go
+++ b/handlers/bind.go
@@ -85,6 +85,11 @@ func (h APIHandler) Bind(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	var metadata any
+	if !binding.Metadata.IsEmpty() {
+		metadata = binding.Metadata
+	}
+
 	if binding.AlreadyExists {
 		h.respond(w, http.StatusOK, requestId, apiresponses.BindingResponse{
 			Credentials:     binding.Credentials,
@@ -92,6 +97,7 @@ func (h APIHandler) Bind(w http.ResponseWriter, req *http.Request) {
 			RouteServiceURL: binding.RouteServiceURL,
 			VolumeMounts:    binding.VolumeMounts,
 			BackupAgentURL:  binding.BackupAgentURL,
+			Metadata:        metadata,
 		})
 		return
 	}
@@ -142,5 +148,6 @@ func (h APIHandler) Bind(w http.ResponseWriter, req *http.Request) {
 		RouteServiceURL: binding.RouteServiceURL,
 		VolumeMounts:    binding.VolumeMounts,
 		BackupAgentURL:  binding.BackupAgentURL,
+		Metadata:        metadata,
 	})
 }

--- a/handlers/get_binding.go
+++ b/handlers/get_binding.go
@@ -57,12 +57,18 @@ func (h APIHandler) GetBinding(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	var metadata any
+	if !binding.Metadata.IsEmpty() {
+		metadata = binding.Metadata
+	}
+
 	h.respond(w, http.StatusOK, requestId, apiresponses.GetBindingResponse{
 		BindingResponse: apiresponses.BindingResponse{
 			Credentials:     binding.Credentials,
 			SyslogDrainURL:  binding.SyslogDrainURL,
 			RouteServiceURL: binding.RouteServiceURL,
 			VolumeMounts:    binding.VolumeMounts,
+			Metadata:        metadata,
 		},
 		Parameters: binding.Parameters,
 	})


### PR DESCRIPTION
Copy of the https://github.com/pivotal-cf/brokerapi/pull/332.

**Description**

According to OSB API Spec, the Binding Object contains a Metadata Object with `expires_at` and `renew_before` which are missing in the current implementation. `expires_at` was introduces in OSB API [2.16](https://github.com/openservicebrokerapi/servicebroker/blob/master/release-notes.md#v216) and `renew_before` in [2.17](https://github.com/openservicebrokerapi/servicebroker/blob/master/release-notes.md#v217).

Changes proposed in this pull request:

- add Metadata Object to Binding.

**Related issue(s)**
https://github.com/kyma-project/kyma-environment-broker/issues/1282